### PR TITLE
Fix #2, Improve Recipes#setRecipeStage(String, IIngredient) performance

### DIFF
--- a/src/main/java/com/blamejared/recipestages/compat/JEIPlugin.java
+++ b/src/main/java/com/blamejared/recipestages/compat/JEIPlugin.java
@@ -31,7 +31,10 @@ public class JEIPlugin implements IModPlugin {
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         recipeRegistry = jeiRuntime.getRecipeRegistry();
         for(IRecipe recipe : Recipes.recipes) {
-            recipeRegistry.hideRecipe(recipeRegistry.getRecipeWrapper(recipe, VanillaRecipeCategoryUid.CRAFTING));
+            IRecipeWrapper recipeWrapper = recipeRegistry.getRecipeWrapper(recipe, VanillaRecipeCategoryUid.CRAFTING);
+            if (recipeWrapper != null) {
+                recipeRegistry.hideRecipe(recipeWrapper);
+            }
         }
     }
 }

--- a/src/main/java/com/blamejared/recipestages/handlers/Recipes.java
+++ b/src/main/java/com/blamejared/recipestages/handlers/Recipes.java
@@ -199,9 +199,7 @@ public class Recipes {
         if (modContainer != null) {
             loader.setActiveModContainer(modContainer);
         }
-        try {
-            recipe.setRegistryName(registryName);
-        } catch (Throwable ignored) {}
+        recipe.setRegistryName(registryName);
         loader.setActiveModContainer(activeModContainer);
     }
     

--- a/src/main/java/com/blamejared/recipestages/handlers/Recipes.java
+++ b/src/main/java/com/blamejared/recipestages/handlers/Recipes.java
@@ -14,6 +14,8 @@ import gnu.trove.set.hash.TIntHashSet;
 import net.minecraft.item.crafting.*;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.IShapedRecipe;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.*;
 import stanhebben.zenscript.annotations.*;
 import stanhebben.zenscript.annotations.Optional;
@@ -26,7 +28,7 @@ import java.util.*;
 public class Recipes {
     
     public static List<IRecipe> recipes = new LinkedList<>();
-    public static Map<ResourceLocation, IItemStack> recipeOutputCache = new HashMap<>();
+    public static ActionSetOutputStages actionSetOutputStages;
     private static TIntSet usedHashes = new TIntHashSet();
     
     @ZenMethod
@@ -97,24 +99,11 @@ public class Recipes {
     
     @ZenMethod
     public static void setRecipeStage(String stage, IIngredient output) {
-        if (recipeOutputCache.isEmpty()) {
-            for (Map.Entry<ResourceLocation, IRecipe> entry : ForgeRegistries.RECIPES.getEntries()) {
-                IItemStack stack = CraftTweakerMC.getIItemStack(entry.getValue().getRecipeOutput());
-                if (stack != null) {
-                    recipeOutputCache.put(entry.getKey(), stack);
-                }
-            }
+        if (actionSetOutputStages == null) {
+            actionSetOutputStages = new ActionSetOutputStages();
+            CraftTweaker.LATE_ACTIONS.add(actionSetOutputStages);
         }
-        for (Map.Entry<ResourceLocation, IItemStack> entry : recipeOutputCache.entrySet()) {
-            IItemStack stack = entry.getValue();
-            if (output.matches(stack)) {
-                IRecipe recipe = ForgeRegistries.RECIPES.getValue(entry.getKey());
-                recipes.add(recipe);
-            }
-        }
-        if(!recipes.isEmpty())
-            CraftTweaker.LATE_ACTIONS.add(new ActionSetStage(recipes, stage));
-        
+        actionSetOutputStages.addOutput(stage, output);
     }
     
     @ZenMethod
@@ -137,27 +126,7 @@ public class Recipes {
         @Override
         public void apply() {
             for(IRecipe irecipe : recipes) {
-                ResourceLocation registryName = irecipe.getRegistryName();
-                if (registryName == null)
-                    continue;
-
-                int width = 0, height = 0;
-                if(irecipe instanceof IShapedRecipe) {
-                    width = ((IShapedRecipe) irecipe).getRecipeWidth();
-                    height = ((IShapedRecipe) irecipe).getRecipeHeight();
-                } else if(irecipe instanceof ShapedRecipe) {
-                    width = ((ShapedRecipe) irecipe).getWidth();
-                    height = ((ShapedRecipe) irecipe).getHeight();
-                } else if(irecipe instanceof ShapedRecipeAdvanced) {
-                    width = ((ShapedRecipe) ((ShapedRecipeAdvanced) irecipe).getRecipe()).getWidth();
-                    height = ((ShapedRecipe) ((ShapedRecipeAdvanced) irecipe).getRecipe()).getHeight();
-                }
-
-                boolean shapeless = (width == 0 && height == 0);
-                ResourceLocation newRegistryName = new ResourceLocation(Reference.MOD_ID, registryName.getResourcePath());
-                IRecipe recipe = new RecipeStage(stage, irecipe, shapeless, width, height).setRegistryName(newRegistryName);
-                ForgeRegistries.RECIPES.register(recipe);
-                Recipes.recipes.add(recipe);
+                replaceRecipe(stage, irecipe);
             }
         }
         
@@ -165,6 +134,75 @@ public class Recipes {
         public String describe() {
             return "Setting the stage for recipes that output: " + recipes.get(0).getRecipeOutput().getDisplayName();
         }
+    }
+
+    private static class ActionSetOutputStages implements IAction {
+        private final Map<String, List<IItemStack>> outputs = new HashMap<>();
+
+        public void addOutput(String stage, IIngredient output) {
+            List<IItemStack> outputsForStage = this.outputs.computeIfAbsent(stage, k -> new ArrayList<>());
+            outputsForStage.addAll(output.getItems());
+        }
+
+        @Override
+        public void apply() {
+            for (IRecipe recipe : ForgeRegistries.RECIPES.getValues()) {
+                IItemStack stack = CraftTweakerMC.getIItemStack(recipe.getRecipeOutput());
+                if (stack != null) {
+                    for (Map.Entry<String, List<IItemStack>> entry : outputs.entrySet()) {
+                        for (IItemStack output : entry.getValue()) {
+                            if (stack.matches(output)) {
+                                replaceRecipe(entry.getKey(), recipe);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            actionSetOutputStages = null;
+        }
+
+        @Override
+        public String describe() {
+            return "Setting the stages for recipes based on their output stack.";
+        }
+    }
+
+    private static void replaceRecipe(String stage, IRecipe iRecipe) {
+        ResourceLocation registryName = iRecipe.getRegistryName();
+        if (registryName == null)
+            return;
+
+        int width = 0, height = 0;
+        if(iRecipe instanceof IShapedRecipe) {
+            width = ((IShapedRecipe) iRecipe).getRecipeWidth();
+            height = ((IShapedRecipe) iRecipe).getRecipeHeight();
+        } else if(iRecipe instanceof ShapedRecipe) {
+            width = ((ShapedRecipe) iRecipe).getWidth();
+            height = ((ShapedRecipe) iRecipe).getHeight();
+        } else if(iRecipe instanceof ShapedRecipeAdvanced) {
+            width = ((ShapedRecipe) ((ShapedRecipeAdvanced) iRecipe).getRecipe()).getWidth();
+            height = ((ShapedRecipe) ((ShapedRecipeAdvanced) iRecipe).getRecipe()).getHeight();
+        }
+
+        boolean shapeless = (width == 0 && height == 0);
+        IRecipe recipe = new RecipeStage(stage, iRecipe, shapeless, width, height);
+        setRecipeRegistryName(recipe, registryName);
+        ForgeRegistries.RECIPES.register(recipe);
+        Recipes.recipes.add(recipe);
+    }
+
+    private static void setRecipeRegistryName(IRecipe recipe, ResourceLocation registryName) {
+        Loader loader = Loader.instance();
+        ModContainer activeModContainer = loader.activeModContainer();
+        ModContainer modContainer = loader.getIndexedModList().get(registryName.getResourceDomain());
+        if (modContainer != null) {
+            loader.setActiveModContainer(modContainer);
+        }
+        try {
+            recipe.setRegistryName(registryName);
+        } catch (Throwable ignored) {}
+        loader.setActiveModContainer(activeModContainer);
     }
     
     private static String calculateName(IIngredient output, IIngredient[][] ingredients) {


### PR DESCRIPTION
This fixes #2 and also has some performance improvements.

Before, Stage 5 recipes script in SevTech takes 32.9 seconds
![recipe-stage-before](https://user-images.githubusercontent.com/916092/33191679-9b6d656c-d070-11e7-96ca-181a90c99709.png)

After, Stage 5 recipes script in SevTech takes 1.5 seconds
![recipe-stage-after](https://user-images.githubusercontent.com/916092/33191681-a0557fa6-d070-11e7-97c9-a54b3304a238.png)

The main cost was creating lots of `IItemStack` each time to check for equality, so I added a cache to do it only one time per recipe.
The next cost was from Forge. Calling `ForgeRegistries.RECIPES.getEntries()` actually makes a copy of the whole entry set each time. I get around this by iterating over the cache instead of the forge registry.