### PR TITLE
Unexpected exception due to obsolete CrT version

### DIFF
--- a/src/main/java/com/blamejared/recipestages/RecipeStages.java
+++ b/src/main/java/com/blamejared/recipestages/RecipeStages.java
@@ -14,7 +14,7 @@ import java.util.*;
 
 import static com.blamejared.recipestages.reference.Reference.*;
 
-@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, dependencies = "required-after:crafttweaker;after:gamestages@[2.0.90,)")
+@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, dependencies = "required-after:crafttweaker@[4.1.12,);after:gamestages@[2.0.90,)")
 public class RecipeStages {
     
     


### PR DESCRIPTION
`java.lang.NoClassDefFoundError: crafttweaker/mc1120/events/ActionApplyEvent$Post`
Obviously RecipeStages calls on an event that doesn't exist before CrT-4.1.12; thus, the game crashed and I thought to add a version requirement will be great.
[crash-2020-02-26_12.43.51-client.txt](https://github.com/jaredlll08/RecipeStages/files/4253488/crash-2020-02-26_12.43.51-client.txt)
