### PR TITLE
Added datapack recipe support

### DIFF
--- a/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
+++ b/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
@@ -1,6 +1,7 @@
 package com.blamejared.recipestages.recipes;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.crafting.*;
 import net.minecraft.network.PacketBuffer;
@@ -16,6 +17,11 @@ public class RecipeStageSerializer extends ForgeRegistryEntry<IRecipeSerializer<
     public RecipeStage read(ResourceLocation recipeId, JsonObject json) {
         String stage = JSONUtils.getString(json, "stage");
         IRecipe<?> recipe = RecipeManager.deserializeRecipe(recipeId, JSONUtils.getJsonObject(json, "recipe"));
+        
+        if (recipe.getType() != IRecipeType.CRAFTING) {
+            throw new JsonSyntaxException("Staged Recipes only work with Crafting Table Recipes");
+        }
+        
         boolean shapeless = json.has("shapeless") ? JSONUtils.getBoolean(json, "shapeless") : (recipe instanceof ShapelessRecipe);
         return new RecipeStage(recipeId, stage, (IRecipe<CraftingInventory>) recipe, shapeless);
     }

--- a/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
+++ b/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.crafting.*;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.registries.*;
 
@@ -13,8 +14,10 @@ public class RecipeStageSerializer extends ForgeRegistryEntry<IRecipeSerializer<
     }
     
     public RecipeStage read(ResourceLocation recipeId, JsonObject json) {
-        // TODO
-        return null;
+        String stage = JSONUtils.getString(json, "stage");
+        IRecipe<?> recipe = RecipeManager.deserializeRecipe(recipeId, JSONUtils.getJsonObject(json, "recipe"));
+        boolean shapeless = json.has("shapeless") ? JSONUtils.getBoolean(json, "shapeless") : (recipe instanceof ShapelessRecipe);
+        return new RecipeStage(recipeId, stage, (IRecipe<CraftingInventory>) recipe, shapeless);
     }
     
     public RecipeStage read(ResourceLocation recipeId, PacketBuffer buffer) {


### PR DESCRIPTION
Example recipe:

```json
{
	"type": "recipestages:stage",
	"stage": "test",
	"recipe": {
		"type": "minecraft:crafting_shaped",
		"pattern": [
			"#",
			"#",
			"#"
		],
		"key": {
			"#": {
				"item": "minecraft:wheat"
			}
		},
		"result": {
			"item": "minecraft:bread"
		}
	}
}
```

![](https://cdn.discordapp.com/attachments/754104284261515354/811267580672475167/unknown.png)