### PR TITLE
Remove references to CraftTweaker's GenericUtil

### DIFF
--- a/src/main/java/com/blamejared/recipestages/RecipeStagesUtil.java
+++ b/src/main/java/com/blamejared/recipestages/RecipeStagesUtil.java
@@ -1,0 +1,11 @@
+package com.blamejared.recipestages;
+
+public class RecipeStagesUtil {
+    
+    @SuppressWarnings("unchecked")
+    public static <T> T cast(Object o) {
+        
+        return (T) o;
+    }
+    
+}

--- a/src/main/java/com/blamejared/recipestages/compat/JEIPlugin.java
+++ b/src/main/java/com/blamejared/recipestages/compat/JEIPlugin.java
@@ -1,7 +1,7 @@
 package com.blamejared.recipestages.compat;
 
 
-import com.blamejared.crafttweaker.api.util.GenericUtil;
+import com.blamejared.recipestages.RecipeStagesUtil;
 import com.blamejared.recipestages.recipes.RecipeStage;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -54,10 +54,10 @@ public class JEIPlugin implements IModPlugin {
                 .forEach((hasStage, recipes) -> {
                     if(hasStage) {
                         JEIPlugin.runTime.getRecipeManager()
-                                .unhideRecipes(RecipeTypes.CRAFTING, GenericUtil.uncheck(recipes));
+                                .unhideRecipes(RecipeTypes.CRAFTING, RecipeStagesUtil.cast(recipes));
                     } else {
                         JEIPlugin.runTime.getRecipeManager()
-                                .hideRecipes(RecipeTypes.CRAFTING, GenericUtil.uncheck(recipes));
+                                .hideRecipes(RecipeTypes.CRAFTING, RecipeStagesUtil.cast(recipes));
                     }
                 });
     }

--- a/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
+++ b/src/main/java/com/blamejared/recipestages/recipes/RecipeStageSerializer.java
@@ -1,6 +1,6 @@
 package com.blamejared.recipestages.recipes;
 
-import com.blamejared.crafttweaker.api.util.GenericUtil;
+import com.blamejared.recipestages.RecipeStagesUtil;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import net.minecraft.network.FriendlyByteBuf;
@@ -60,7 +60,7 @@ public class RecipeStageSerializer extends ForgeRegistryEntry<RecipeSerializer<?
         }
         buffer.writeResourceLocation(recipe1.getId());
         buffer.writeResourceLocation(recipe1.getSerializer().getRegistryName());
-        recipe1.getSerializer().toNetwork(buffer, GenericUtil.uncheck(recipe1));
+        recipe1.getSerializer().toNetwork(buffer, RecipeStagesUtil.cast(recipe1));
         buffer.writeUtf(recipe.getStage());
         buffer.writeBoolean(recipe.isShapeless());
     }


### PR DESCRIPTION
Since CraftTweaker was made an optional dependency in #49 and this is a "non-essential" reference to CraftTweaker code, I replaced any calls to `GenericUtil.uncheck` within the mod with our own utility method `RecipeStagesUtil.cast`. This should fix any crashes that might arise from actually using RecipeStages without CraftTweaker in production ^^